### PR TITLE
Allow setting background color and defaultStrokeOpacity as props

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ const stylingFunction = (context : any) => {
 | tooltipTextColor    | string  | Tooltip text color |
 | valuePrefix         | string  | A string to prefix values in tooltips. E.g. "$" |
 | valueSuffix         | string  | A string to suffix values in tooltips. E.g. "USD" |
+| backgroundColor     | string  | Component background color |
+| defaultStrokeOpacity| string  | The stroke opacity of non selected countries |
 | frame               | boolean | true/false for drawing a frame around the map |
 | frameColor          | string  | Frame color |
 | borderColor         | string  | Border color around each individual country. "black" by default |

--- a/src/WorldMap.tsx
+++ b/src/WorldMap.tsx
@@ -25,6 +25,8 @@ interface IProps {
   valuePrefix?: string,
   valueSuffix?: string,
   color?: string,
+  defaultStrokeOpacity?: number
+  backgroundColor?: string, 
   tooltipBgColor?: string,
   tooltipTextColor?: string,
   size?: string, // possile values are sm, md, lg
@@ -93,6 +95,8 @@ export const WorldMap: React.FC<IProps> = (props) => {
   const tooltipBgColor = (typeof (props.tooltipBgColor) === "undefined") ? "black" : props.tooltipBgColor
   const tooltipTextColor = (typeof (props.tooltipTextColor) === "undefined") ? "white" : props.tooltipTextColor
   const isFrame = (typeof (props.frame) === "undefined") ? false : props.frame
+  const backgroundColor = (typeof (props.backgroundColor) === "undefined") ? "white" : props.backgroundColor
+  const defaultStrokeOpacity = (typeof (props.defaultStrokeOpacity) === "undefined") ? 0.2 : props.defaultStrokeOpacity
   const frameColor = (typeof (props.frameColor) === "undefined") ? "black" : props.frameColor
   const borderColor = (typeof (props.borderColor) === "undefined") ? "black" : props.borderColor
   const frame = isFrame ? <rect x={0} y={0} width={"100%"} height={"100%"} stroke={frameColor} fill="none" /> : <path></path>
@@ -105,7 +109,7 @@ export const WorldMap: React.FC<IProps> = (props) => {
   const defaultCountryStyle = (context : ICountryContext) => {
     const contextCountryValue = context.countryValue ? context.countryValue : 0
     const opacityLevel = 0.2 + (0.6 * (contextCountryValue - context.minValue) / (context.maxValue - context.minValue))
-    const style={ fill: context.color, fillOpacity: contextCountryValue === 0 ? contextCountryValue : opacityLevel, stroke: borderColor, strokeWidth: 1, strokeOpacity: 0.2, cursor: "pointer" }
+    const style={ fill: context.color, fillOpacity: contextCountryValue === 0 ? contextCountryValue : opacityLevel, stroke: borderColor, strokeWidth: 1, strokeOpacity: props.defaultStrokeOpacity, cursor: "pointer" }
     return style;
   }
 
@@ -141,7 +145,7 @@ export const WorldMap: React.FC<IProps> = (props) => {
       d={pathGenerator(geoFeature as GeoJSON.Feature) as string}
       style={style}
       onMouseOver={(event) => { event.currentTarget.style.strokeWidth = "2"; event.currentTarget.style.strokeOpacity = "0.5" }}
-      onMouseOut={(event) => { event.currentTarget.style.strokeWidth = "1"; event.currentTarget.style.strokeOpacity = "0.2" }}
+      onMouseOut={(event) => { event.currentTarget.style.strokeWidth = "1"; event.currentTarget.style.strokeOpacity = `${defaultStrokeOpacity}` }}
     />
 
     const marker = (typeof (countryValueMap[feature.I]) === "undefined") ? <g pointerEvents={"none"} key={"path" + idx + "abc"}></g>
@@ -181,7 +185,7 @@ export const WorldMap: React.FC<IProps> = (props) => {
 
   // Render the SVG
   return (
-    <div style={{ backgroundColor: "white", height: "auto", width: "auto", padding: "0px", margin: "0px" }}>
+    <div style={{ backgroundColor: backgroundColor, height: "auto", width: "auto", padding: "0px", margin: "0px" }}>
       {title}
       <svg ref={containerRef} height={height + "px"} width={width + "px"}>
         {frame}


### PR DESCRIPTION
Since the background color was set to white, the component does not look
good in different backgrounds. Additionaly, the default path opacity
(0.2) is too transparent for light backgrounds.

This commit exposes properties to configure those parameters.