### PR TITLE
Provide the correct output format

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "scripts": {
     "start": "tsdx watch",
     "minify": "terser --compress --mangle --output ./dist/react-svg-worldmap.min.esm.js -- ./dist/react-svg-worldmap.esm.js",
-    "build": "tsdx build --format esm && terser --compress --mangle --output ./dist/react-svg-worldmap.esm.js -- ./dist/react-svg-worldmap.esm.js",
+    "build": "tsdx build && terser --compress --mangle --output ./dist/react-svg-worldmap.esm.js -- ./dist/react-svg-worldmap.esm.js",
     "test": "tsdx test --passWithNoTests",
     "lint": "tsdx lint",
-    "prepare": "tsdx build --format esm && terser --compress --mangle --output ./dist/react-svg-worldmap.esm.js -- ./dist/react-svg-worldmap.esm.js"
+    "prepare": "tsdx build && terser --compress --mangle --output ./dist/react-svg-worldmap.esm.js -- ./dist/react-svg-worldmap.esm.js"
   },
   "peerDependencies": {
     "react": ">=16",


### PR DESCRIPTION
To be able to use this module in TypeScript and Non-TypeScript projects, the `format` option has been removed. This way `tsdx` will automatically create code in the esm and cjs format.