### PR TITLE
Add href function & type fixes & RFC for more polishments

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ const clickAction = (event: React.MouseEvent<SVGElement, MouseEvent>, countryNam
 | Prop                | Type    | Description |
 | ------------------- | ------- | ----------- |
 | data                | Array   | Mandatory. Array of JSON records, each with country/value. |
-| size                | string  | The size of your map, either "sm", md", "lg", "xl", "xxl", or "resposive", read about responsive below. |
+| size                | string  | The size of your map, either "sm", md", "lg", "xl", "xxl", or "responsive", read about responsive below. |
 | title               | string  | Any string for the title of your map |
 | color               | string  | Color for highlighted countries. A standard color string. E.g. "red" or "#ff0000" |
 | tooltipBgColor      | string  | Tooltip background color |
@@ -168,8 +168,9 @@ const clickAction = (event: React.MouseEvent<SVGElement, MouseEvent>, countryNam
 | frameColor          | string  | Frame color |
 | borderColor         | string  | Border color around each individual country. "black" by default |
 | :construction: type :construction:              | string  | Select type of map you want, either "tooltip" or "marker". :memo: This functionality not only complicated the code, but was infrequently used and needs to be rethought to make it better. For simplicity sake, I have deprecated this functionality for the time being pending on a more elegant solution. :memo: |
-| styleFunction       | (context: any) => {}  | A callback function to customize styling of each country (see custom-style-example) |
-| tooltipTextFunction | (countryName: string, isoCode: string, value: string, prefix?: string, suffix?: string) => {}  | A callback function to customize tooltip text (see localization-example) |
+| styleFunction       | (context: any) => CSSProperties  | A callback function to customize styling of each country (see custom-style-example) |
+| hrefFunction       | (countryName: string, isoCode: string, value: string, prefix?: string, suffix?: string) => string  | A callback function to bind an href link to each country (see links-example) |
+| tooltipTextFunction | (countryName: string, isoCode: string, value: string, prefix?: string, suffix?: string) => string  | A callback function to customize tooltip text (see localization-example) |
 
 ## Responsive Size
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ const clickAction = (event: React.MouseEvent<SVGElement, MouseEvent>, countryNam
 | borderColor         | string  | Border color around each individual country. "black" by default |
 | :construction: type :construction:              | string  | Select type of map you want, either "tooltip" or "marker". :memo: This functionality not only complicated the code, but was infrequently used and needs to be rethought to make it better. For simplicity sake, I have deprecated this functionality for the time being pending on a more elegant solution. :memo: |
 | styleFunction       | (context: any) => CSSProperties  | A callback function to customize styling of each country (see custom-style-example) |
-| hrefFunction       | (countryName: string, isoCode: string, value: string, prefix?: string, suffix?: string) => string  | A callback function to bind an href link to each country (see links-example) |
+| hrefFunction       | (countryName: string, isoCode: string, value: string, prefix?: string, suffix?: string) => string | undefined  | A callback function to bind an href link to each country (see links-example) |
 | tooltipTextFunction | (countryName: string, isoCode: string, value: string, prefix?: string, suffix?: string) => string  | A callback function to customize tooltip text (see localization-example) |
 
 ## Responsive Size

--- a/examples/links/.npmignore
+++ b/examples/links/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+.cache
+dist/
+../../node_modules

--- a/examples/links/package.json
+++ b/examples/links/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "my-app",
+  "version": "0.1.0",
+  "dependencies": {
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.5.0",
+    "@testing-library/user-event": "^7.2.1",
+    "@types/d3-geo": "^1.12.1",
+    "@types/jest": "^24.9.1",
+    "@types/node": "^12.19.15",
+    "@types/react": "^16.14.2",
+    "@types/react-dom": "^16.9.10",
+    "d3-geo": "^1.12.1",
+    "fibers": "^5.0.0",
+    "node-sass": "^4.14.1",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
+    "react-path-tooltip": "^1.0.14",
+    "react-scripts": "^3.4.4",
+    "react-svg-worldmap": "file:../../lib/react-svg-worldmap-1.1.0.tgz",
+    "sass": "^1.32.5",
+    "typescript": "^3.9.7"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/examples/links/public/index.html
+++ b/examples/links/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Sample app created using create-react-app"
+    />
+    <title>Sample App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/links/src/App.css
+++ b/examples/links/src/App.css
@@ -1,0 +1,38 @@
+.App {
+  text-align: center;
+}
+
+.App-logo {
+  height: 40vmin;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .App-logo {
+    animation: App-logo-spin infinite 20s linear;
+  }
+}
+
+.App-header {
+  background-color: #282c34;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
+
+.App-link {
+  color: #61dafb;
+}
+
+@keyframes App-logo-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/examples/links/src/App.test.tsx
+++ b/examples/links/src/App.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import App from './App';
+
+test('renders learn react link', () => {
+  const { getByText } = render(<App />);
+  const linkElement = getByText(/learn react/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/examples/links/src/App.tsx
+++ b/examples/links/src/App.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react"
+import "./App.css"
+import { WorldMap } from "react-svg-worldmap"
+
+function App() {
+
+  // data array
+  const data =
+    [
+      { "country": "cn", value: 1389618778 }, // china
+      { "country": "in", value: 1311559204 }, // india
+      { "country": "us", value: 331883986 },  // united states
+      { "country": "id", value: 264935824 },  // indonesia
+      { "country": "br", value: 210301591 },  // brazil
+      { "country": "ng", value: 208679114 },  // nigeria
+      { "country": "ru", value: 141944641 },  // russia
+      { "country": "mx", value: 127318112 }   // mexico
+    ]
+  const getHref = (event: React.MouseEvent<SVGElement, MouseEvent>, countryName: string, isoCode: string, value: string, prefix?: string, suffix?: string) => `https://en.wikipedia.org/wiki/${countryName.replace(/\s/g, '%20')}`
+
+  return (
+    < div className="App" >
+      < div className="Main">
+        <WorldMap
+          title="The ten highest GDP per capita countries"
+          size="xl"
+          data={data}
+          hrefFunction={getHref} />
+        <div>
+          <p>
+              Country: {state.cName}
+          </p>
+          <p>Iso Code: {state.iso}</p>
+          <p>GDP per capita: {state.val}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default App;

--- a/examples/links/src/index.css
+++ b/examples/links/src/index.css
@@ -1,0 +1,13 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/examples/links/src/index.tsx
+++ b/examples/links/src/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import './index.css';
+import App from './App';
+import * as serviceWorker from './serviceWorker';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);
+
+// If you want your app to work offline and load faster, you can change
+// unregister() to register() below. Note this comes with some pitfalls.
+// Learn more about service workers: https://bit.ly/CRA-PWA
+serviceWorker.unregister();

--- a/examples/links/src/react-app-env.d.ts
+++ b/examples/links/src/react-app-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="react-scripts" />
+declare module 'react-svg-worldmap';

--- a/examples/links/src/serviceWorker.ts
+++ b/examples/links/src/serviceWorker.ts
@@ -1,0 +1,149 @@
+// This optional code is used to register a service worker.
+// register() is not called by default.
+
+// This lets the app load faster on subsequent visits in production, and gives
+// it offline capabilities. However, it also means that developers (and users)
+// will only see deployed updates on subsequent visits to a page, after all the
+// existing tabs open on the page have been closed, since previously cached
+// resources are updated in the background.
+
+// To learn more about the benefits of this model and instructions on how to
+// opt-in, read https://bit.ly/CRA-PWA
+
+const isLocalhost = Boolean(
+  window.location.hostname === 'localhost' ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === '[::1]' ||
+    // 127.0.0.0/8 are considered localhost for IPv4.
+    window.location.hostname.match(
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+    )
+);
+
+type Config = {
+  onSuccess?: (registration: ServiceWorkerRegistration) => void;
+  onUpdate?: (registration: ServiceWorkerRegistration) => void;
+};
+
+export function register(config?: Config) {
+  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    // The URL constructor is available in all browsers that support SW.
+    const publicUrl = new URL(
+      process.env.PUBLIC_URL,
+      window.location.href
+    );
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if PUBLIC_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets; see https://github.com/facebook/create-react-app/issues/2374
+      return;
+    }
+
+    window.addEventListener('load', () => {
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+
+      if (isLocalhost) {
+        // This is running on localhost. Let's check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl, config);
+
+        // Add some additional logging to localhost, pointing developers to the
+        // service worker/PWA documentation.
+        navigator.serviceWorker.ready.then(() => {
+          console.log(
+            'This web app is being served cache-first by a service ' +
+              'worker. To learn more, visit https://bit.ly/CRA-PWA'
+          );
+        });
+      } else {
+        // Is not localhost. Just register service worker
+        registerValidSW(swUrl, config);
+      }
+    });
+  }
+}
+
+function registerValidSW(swUrl: string, config?: Config) {
+  navigator.serviceWorker
+    .register(swUrl)
+    .then(registration => {
+      registration.onupdatefound = () => {
+        const installingWorker = registration.installing;
+        if (installingWorker == null) {
+          return;
+        }
+        installingWorker.onstatechange = () => {
+          if (installingWorker.state === 'installed') {
+            if (navigator.serviceWorker.controller) {
+              // At this point, the updated precached content has been fetched,
+              // but the previous service worker will still serve the older
+              // content until all client tabs are closed.
+              console.log(
+                'New content is available and will be used when all ' +
+                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
+              );
+
+              // Execute callback
+              if (config && config.onUpdate) {
+                config.onUpdate(registration);
+              }
+            } else {
+              // At this point, everything has been precached.
+              // It's the perfect time to display a
+              // "Content is cached for offline use." message.
+              console.log('Content is cached for offline use.');
+
+              // Execute callback
+              if (config && config.onSuccess) {
+                config.onSuccess(registration);
+              }
+            }
+          }
+        };
+      };
+    })
+    .catch(error => {
+      console.error('Error during service worker registration:', error);
+    });
+}
+
+function checkValidServiceWorker(swUrl: string, config?: Config) {
+  // Check if the service worker can be found. If it can't reload the page.
+  fetch(swUrl, {
+    headers: { 'Service-Worker': 'script' }
+  })
+    .then(response => {
+      // Ensure service worker exists, and that we really are getting a JS file.
+      const contentType = response.headers.get('content-type');
+      if (
+        response.status === 404 ||
+        (contentType != null && contentType.indexOf('javascript') === -1)
+      ) {
+        // No service worker found. Probably a different app. Reload the page.
+        navigator.serviceWorker.ready.then(registration => {
+          registration.unregister().then(() => {
+            window.location.reload();
+          });
+        });
+      } else {
+        // Service worker found. Proceed as normal.
+        registerValidSW(swUrl, config);
+      }
+    })
+    .catch(() => {
+      console.log(
+        'No internet connection found. App is running in offline mode.'
+      );
+    });
+}
+
+export function unregister() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready
+      .then(registration => {
+        registration.unregister();
+      })
+      .catch(error => {
+        console.error(error.message);
+      });
+  }
+}

--- a/examples/links/src/setupTests.ts
+++ b/examples/links/src/setupTests.ts
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom/extend-expect';

--- a/examples/links/tsconfig.json
+++ b/examples/links/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/lib/.eslintrc.json
+++ b/lib/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "browser": true,
         "es2021": true

--- a/lib/src/WorldMap.tsx
+++ b/lib/src/WorldMap.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { CSSProperties } from 'react'
 import GeoJSON from 'geojson'
 import { geoMercator, geoPath } from 'd3-geo'
 import { PathTooltip } from 'react-path-tooltip'
@@ -18,40 +18,53 @@ interface ICountryContext {
   maxValue: number
 }
 
+type SizeOption = 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'responsive';
+
 interface IProps {
   data: IData[],
   title?: string,
   valuePrefix?: string,
   valueSuffix?: string,
   color?: string,
-  strokeOpacity?: number
+  strokeOpacity?: number,
   backgroundColor?: string,
   tooltipBgColor?: string,
   tooltipTextColor?: string,
-  size?: string, // possile values are sm, md, lg
+  size?: SizeOption,
   frame?: boolean,
   frameColor?: string,
   // type?: string, // depracated for the time being (reasoning in the README.md file)
 
-  styleFunction?: (context: ICountryContext) => {
+  styleFunction?: (context: ICountryContext) => CSSProperties,
 
-  },
-
-  onClickFunction?:
-
-  (event: React.MouseEvent<SVGElement, Event>, countryName: string,
-
-    isoCode: string, value: string, prefix: string, suffix: string) => {
-
-    },
+  onClickFunction?: (
+    event: React.MouseEvent<SVGElement, Event>,
+    countryName: string,
+    isoCode: string,
+    value: string,
+    prefix: string,
+    suffix: string,
+  ) => void,
     
-  tooltipTextFunction?:
+  tooltipTextFunction?: (
+    countryName: string,
+    isoCode: string,
+    value: string,
+    prefix: string,
+    suffix: string,
+  ) => string,
 
-  (countryName: string, isoCode: string, value: string, prefix: string, suffix: string) => string,
+  hrefFunction?: (
+    countryName: string,
+    isoCode: string,
+    value: string,
+    prefix: string,
+    suffix: string,
+  ) => string,
   borderColor?: string
 }
 
-const CSizes: { [key: string]: number } = {
+const CSizes: Record<SizeOption, number> = {
   sm: 240,
   md: 336,
   lg: 480,
@@ -82,7 +95,7 @@ export const WorldMap: React.FC<IProps> = (props : IProps) => {
   const size = typeof (props.size) !== 'undefined' ? props.size : 'sm'
 
   // adjust responsive size
-  const responsify = (sz: string) => {
+  const responsify = (sz: SizeOption) => {
     let realSize = sz
     if (sz === 'responsive') {
       return Math.min(window.innerHeight, window.innerWidth) * 0.75
@@ -179,6 +192,9 @@ export const WorldMap: React.FC<IProps> = (props : IProps) => {
           props.onClickFunction(e, countryName, isoCode, countryValueMap[isoCode].toString(), valuePrefix || '', valueSuffix || '')
         }
       }}
+      {...(props.hrefFunction ? {
+        href: props.hrefFunction(countryName, isoCode, countryValueMap[isoCode].toString(), valuePrefix || '', valueSuffix || '')
+      } : undefined)}
 
       onMouseOver={(event) => { event.currentTarget.style.strokeWidth = '2'; event.currentTarget.style.strokeOpacity = '0.5' }}
 

--- a/lib/src/WorldMap.tsx
+++ b/lib/src/WorldMap.tsx
@@ -33,7 +33,8 @@ interface IProps {
   size?: SizeOption,
   frame?: boolean,
   frameColor?: string,
-  // type?: string, // depracated for the time being (reasoning in the README.md file)
+  /** @deprecated */
+  type?: string, // depracated for the time being (reasoning in the README.md file)
 
   styleFunction?: (context: ICountryContext) => CSSProperties,
 
@@ -60,7 +61,7 @@ interface IProps {
     value: string,
     prefix: string,
     suffix: string,
-  ) => string,
+  ) => string | undefined,
   borderColor?: string
 }
 
@@ -182,6 +183,8 @@ export const WorldMap: React.FC<IProps> = (props : IProps) => {
       maxValue: max,
     })
 
+    const href = props.hrefFunction?.(countryName, isoCode, countryValueMap[isoCode].toString(), valuePrefix || '', valueSuffix || '')
+
     const path = <path
       key={`path${idx}`}
       ref={triggerRef}
@@ -192,9 +195,7 @@ export const WorldMap: React.FC<IProps> = (props : IProps) => {
           props.onClickFunction(e, countryName, isoCode, countryValueMap[isoCode].toString(), valuePrefix || '', valueSuffix || '')
         }
       }}
-      {...(props.hrefFunction ? {
-        href: props.hrefFunction(countryName, isoCode, countryValueMap[isoCode].toString(), valuePrefix || '', valueSuffix || '')
-      } : undefined)}
+      {...(href ? {href} : undefined)}
 
       onMouseOver={(event) => { event.currentTarget.style.strokeWidth = '2'; event.currentTarget.style.strokeOpacity = '0.5' }}
 


### PR DESCRIPTION
Hey @yanivam, I'm using this project for our org's website and it works really well, thanks for working on this!

I've added a new API called `hrefFunction` which can bind `href` property to each country, because implementing this with just the `onclick` API can be really awkward.

In addition I've improved the typing because my TS keeps giving me some really minor errors.

If you are available to review this, I'd also like to ask you if you would consider the following polishing contributions (I'd be glad to work on them, just not sure of your preferences):

- [ ] #89
  - What is the benefit? Users just need to run `yarn install` at the repo root, and dependencies will be installed and synchronized across all the sub-packages. The built `react-svg-worldmap` will also be vendored as one of the dependencies for the examples. This ensures that all the packages are using the same dependency version and prevents potential bugs.
  - What do we need to do? Just some tweaks in the `package.json` file, and (optionally) write some scripts for auto-building and auto-publishing.
  - More suggestion: I don't suggest you to git ignore the `yarn.lock` file because committing the lock file helps to synchronize dependency versions across forks;
- [ ] The code style doesn't look good although you have ESLint installed, I can help you improve & unify code style and we can definitely discuss more about your preferences;
- [ ] You can publish your examples on a GitHub pages site so people can see them in action. I suggest you build one, and I'll be available if you need help;
- [ ] I'm also thinking about refactoring the API because `styleFunction` sounds less straightforward than `getStyle`. Also, I suggest you pass all parameters as one object, like `getTooltipText({countryName, isoCode, value, prefix, suffix})` (note the extra braces).
  - What is the benefit? Well, users don't have to use all parameters and they can just destructure things they actually need, leading to less unused placeholder variable names: ``getTooltipText={({countryName}) => `Hello ${countryName}!`}``
  - What's the downside? Users can't conveniently rename the parameters unless they do something like: `getTooltipText={({countryName: name}) => "Hello ${name}!"}`. However, this is not a bad thing because other code readers can easily understand that `name` stands for `countryName`.
  - ***This would be a breaking change.*** We either want to release a new major version (`2.0.0`) if you are willing to make this change, or we just add a backward-compatible function overload. Since we are changing both the name and the parameters, just creating new APIs without touching old ones may actually work.
- [ ] A minor suggestion: **enforce squash merging**. This way each PR will become one single commit on master, and we don't pollute the master branch with all kinds of merge commits and patch commits. You can do so by going to settings and unchecking the other two options under "merge button".

We don't have to do all these within this PR—we can talk about what you want here, and then I can create new PRs to help you get started