### PR TITLE
no viewbox makes this impossible to scale to fit parent

### DIFF
--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -145,8 +145,7 @@ export default function WorldMap(props: Props): JSX.Element {
       )}
       <svg
         ref={containerRef}
-        height={`${height}px`}
-        width={`${width}px`}
+        viewBox={`0 0 ${width} ${height}`}
         {...(richInteraction ? eventHandlers : undefined)}
       >
         {frame && <Frame color={frameColor} />}


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1860848/147802146-29e4f4f7-7043-46e8-b3ab-14ce2454156c.png)

after
![image](https://user-images.githubusercontent.com/1860848/147802133-c5dcc741-d431-40a2-b42e-6e7699846edb.png)
