### PR TITLE
fix: make opacity correctly calculated with only one country value

### DIFF
--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -16,9 +16,14 @@ export const defaultCountryStyle =
   (stroke: string, strokeOpacity: number) =>
   (context: CountryContext): CSSProperties => {
     const {countryValue, minValue, maxValue, color} = context;
-    const opacityLevel = countryValue
+    let opacityLevel = countryValue
       ? 0.2 + 0.6 * ((countryValue - minValue) / (maxValue - minValue))
       : 0;
+    
+    if (isNan(opacityLevel)) {
+      opacityLevel = 0.8
+    }
+    
     const style = {
       fill: color,
       fillOpacity: opacityLevel,

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -20,8 +20,10 @@ export const defaultCountryStyle =
       ? 0.2 + 0.6 * ((countryValue - minValue) / (maxValue - minValue))
       : 0;
     
-    if (isNan(opacityLevel)) {
-      opacityLevel = 0.8
+    // If there's only one value, the calculation would be dividing by zero.
+    // We adjust it to the maximum value.
+    if (Number.isNaN(opacityLevel)) {
+      opacityLevel = 0.8;
     }
     
     const style = {


### PR DESCRIPTION
When passing only one country in the data array, the calculation for the opacity fails. 

That is because `maxValue - minValue` will result in 0 and we divide by zero which result in Infinity / 'NaN'. Therefore the "fillOpacity" will not get a value which results in fillOpacity: 1, which is different from the `0.2 + 0.6 * ...` which can only result in max 0.8 for fillOpacity. 

Don't know if the suggested change is the best way to solve this, I just want to point that out.