### PR TITLE
feat: support string value

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -49,13 +49,13 @@ type SizeOption = "sm" | "md" | "lg" | "xl" | "xxl";
 
 type DataItem = {
   country: ISOCode;
-  value: number;
+  value: number | string;
 };
 
 type CountryContext = {
   countryCode: ISOCode;
   countryName: string;
-  countryValue: number | undefined;
+  countryValue: number | string | undefined;
   color: string;
   minValue: number;
   maxValue: number;

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -8,7 +8,9 @@ sidebar_position: 3
 
 This is an optional more advanced customization option. When used, the developer has full control to define the color, opacity and any other style element of a country with data record.
 
-This is done by passing your custom implementation of the `styleFunction`. The function receives as input the country context that includes `country`, `countryValue`, `color`, `minValue` and `maxValue`, and returns a React `CSSProperties` object. Note that `countryValue` can be undefined, for which case you may need to handle the styling differently.
+This is done by passing your custom implementation of the `styleFunction`.
+The function receives as input the country context that includes `country`, `countryValue`, `color`, `minValue` and `maxValue`, and returns a React `CSSProperties` object.
+Note that `countryValue` can be a number, string, or undefined, for which case you may need to handle the styling differently.
 
 For example:
 
@@ -22,9 +24,13 @@ const stylingFunction = ({
   country,
   color,
 }: CountryContext) => {
-  const opacityLevel = countryValue
-    ? 0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue)
-    : 0;
+  let opacityLevel = 0;
+  if (typeof countryValue === "number") {
+    opacityLevel =
+      0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue);
+  } else if (typeof countryValue === "string") {
+    opacityLevel = 0.8;
+  }
   return {
     fill: country === "US" ? "blue" : color,
     fillOpacity: opacityLevel,

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -26,7 +26,7 @@ const stylingFunction = ({
     typeof countryValue === "string" ? minValue : countryValue;
   const opacityLevel =
     calculatedValue !== undefined
-      ? 0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue)
+      ? 0.1 + (1.5 * (calculatedValue - minValue)) / (maxValue - minValue)
       : 0;
   return {
     fill: country === "US" ? "blue" : color,

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -8,9 +8,7 @@ sidebar_position: 3
 
 This is an optional more advanced customization option. When used, the developer has full control to define the color, opacity and any other style element of a country with data record.
 
-This is done by passing your custom implementation of the `styleFunction`.
-The function receives as input the country context that includes `country`, `countryValue`, `color`, `minValue` and `maxValue`, and returns a React `CSSProperties` object.
-Note that `countryValue` can be a number, string, or undefined, for which case you may need to handle the styling differently.
+This is done by passing your custom implementation of the `styleFunction`. The function receives as input the country context that includes `country`, `countryValue`, `color`, `minValue` and `maxValue`, and returns a React `CSSProperties` object. Note that `countryValue` can be a number, string, or undefined, for which case you may need to handle the styling differently.
 
 For example:
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -23,7 +23,7 @@ const stylingFunction = ({
   color,
 }: CountryContext) => {
   const calculatedValue = typeof countryValue === "string" ? minValue : countryValue;
-  const opacityLevel = countryValue !== undefined
+  const opacityLevel = countryValue !== undefined 
     ? 0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue)
     : 0;
   return {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -22,10 +22,12 @@ const stylingFunction = ({
   country,
   color,
 }: CountryContext) => {
-  const calculatedValue = typeof countryValue === "string" ? minValue : countryValue;
-  const opacityLevel = countryValue !== undefined 
-    ? 0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue)
-    : 0;
+  const calculatedValue =
+    typeof countryValue === "string" ? minValue : countryValue;
+  const opacityLevel =
+    countryValue !== undefined
+      ? 0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue)
+      : 0;
   return {
     fill: country === "US" ? "blue" : color,
     fillOpacity: opacityLevel,

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -25,7 +25,7 @@ const stylingFunction = ({
   const calculatedValue =
     typeof countryValue === "string" ? minValue : countryValue;
   const opacityLevel =
-    countryValue !== undefined
+    calculatedValue !== undefined
       ? 0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue)
       : 0;
   return {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -22,13 +22,10 @@ const stylingFunction = ({
   country,
   color,
 }: CountryContext) => {
-  let opacityLevel = 0;
-  if (typeof countryValue === "number") {
-    opacityLevel =
-      0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue);
-  } else if (typeof countryValue === "string") {
-    opacityLevel = 0.8;
-  }
+  const calculatedValue = typeof countryValue === "string" ? minValue : countryValue;
+  const opacityLevel = countryValue !== undefined
+    ? 0.1 + (1.5 * (countryValue - minValue)) / (maxValue - minValue)
+    : 0;
   return {
     fill: country === "US" ? "blue" : color,
     fillOpacity: opacityLevel,

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -64,5 +64,5 @@ sidebar_position: 5
 
 - Some users do not have a need to display numeric values.
 - This is an example showing how each data value can have a string value.
-- The same thing can be accomplished with `tooptipTextFunction`, by hiding the number value and adding your string to the Country value (see [localization](/examples/localization)), but this will make that user experience easier.
+- The same thing can be accomplished with `tooltipTextFunction`, by hiding the number value and adding your string to the Country value (see [localization](/examples/localization)), but this will make that user experience easier.
 - If you are using both string and number values together, string will be treated as `minValue`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -65,3 +65,4 @@ sidebar_position: 5
 - Some users do not have a need to display numeric values.
 - This is an example showing how each data value can have a string value.
 - The same thing can be accomplished with `tooptipTextFunction`, by hiding the number value and adding your string to the Country value (see [localization](/examples/localization)), but this will make that user experience easier.
+- If you are using both string and number values together, string will be treated as `minValue`.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -59,3 +59,9 @@ sidebar_position: 5
 
 - An example showing how a map with rich interactions enabled is like.
 - Try double-clicking on the map!
+
+## [examples/string-value](/examples/string-value)
+
+- Some users do not have a need to display numeric values.
+- This is an example showing how each data value can have a string value.
+- The same thing can be accomplished with `tooptipTextFunction`, by hiding the number value and adding your string to the Country value (see [localization](/examples/localization)), but this will make that user experience easier.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -51,7 +51,7 @@ function App() {
 }
 ```
 
-The only mandatory prop is `data`, which contains an array of country/value objects, with values for countries that you have values for. (Countries without a value will be blank.) The country code is a 2 character string representing the country ([ISO alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)) and value is a number.
+The only mandatory prop is `data`, which contains an array of country/value objects, with values for countries that you have values for. (Countries without a value will be blank.) The country code is a 2 character string representing the country ([ISO alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)) and `value` is a number or string.
 
 ## Class components
 

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -18,11 +18,11 @@ export const defaultCountryStyle =
     const { countryValue, minValue, maxValue, color } = context;
 
     const calculatedValue =
-      // TODO bug in TS-ESLint; report this
-       
       typeof countryValue === "string"
         ? minValue
-        : (countryValue );
+        : // TODO bug in TS-ESLint; report this
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+          (countryValue as number | undefined);
     let opacityLevel =
       calculatedValue !== undefined
         ? 0.2 + 0.6 * ((calculatedValue - minValue) / (maxValue - minValue))

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -14,13 +14,15 @@ export const sizeMap: Record<SizeOption, number> = {
 
 export const defaultCountryStyle =
   (stroke: string, strokeOpacity: number) =>
-  (context: CountryContext): CSSProperties => {
+  <T extends string | number>(context: CountryContext<T>): CSSProperties => {
     const { countryValue, minValue, maxValue, color } = context;
 
-    const calculatedValue = typeof countryValue === "string" ? minValue : countryValue;
-    let opacityLevel = calculatedValue !== undefined 
-      ? 0.2 + 0.6 * ((calculatedValue - minValue) / (maxValue - minValue))
-      : 0;
+    const calculatedValue =
+      typeof countryValue === "string" ? minValue : countryValue;
+    let opacityLevel =
+      calculatedValue !== undefined
+        ? 0.2 + 0.6 * ((calculatedValue - minValue) / (maxValue - minValue))
+        : 0;
 
     // If there's only one value, the calculation would be dividing by zero.
     // We adjust it to the maximum value.
@@ -37,7 +39,9 @@ export const defaultCountryStyle =
     return style;
   };
 
-export const defaultTooltip = (context: CountryContext): string => {
+export const defaultTooltip = <T extends string | number>(
+  context: CountryContext<T>,
+): string => {
   const { countryName, countryValue, prefix, suffix } = context;
   return `${countryName} ${prefix} ${countryValue!.toLocaleString()} ${suffix}`;
 };

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -17,13 +17,10 @@ export const defaultCountryStyle =
   (context: CountryContext): CSSProperties => {
     const { countryValue, minValue, maxValue, color } = context;
 
-    let opacityLevel = 0;
-    if (typeof countryValue === "number") {
-      opacityLevel =
-        0.2 + 0.6 * ((countryValue - minValue) / (maxValue - minValue));
-    } else if (typeof countryValue === "string") {
-      opacityLevel = 0.8;
-    }
+    const calculatedValue = typeof countryValue === "string" ? minValue : countryValue;
+    let opacityLevel = calculatedValue !== undefined
+      ? 0.2 + 0.6 * ((calculatedValue - minValue) / (maxValue - minValue))
+      : 0;
 
     // If there's only one value, the calculation would be dividing by zero.
     // We adjust it to the maximum value.

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -16,9 +16,12 @@ export const defaultCountryStyle =
   (stroke: string, strokeOpacity: number) =>
   (context: CountryContext): CSSProperties => {
     const { countryValue, minValue, maxValue, color } = context;
-    let opacityLevel = countryValue
-      ? 0.2 + 0.6 * ((countryValue - minValue) / (maxValue - minValue))
-      : 0;
+
+    let opacityLevel = 0;
+    if (typeof countryValue === "number")
+      opacityLevel =
+        0.2 + 0.6 * ((countryValue - minValue) / (maxValue - minValue));
+    else if (typeof countryValue === "string") opacityLevel = 0.8;
 
     // If there's only one value, the calculation would be dividing by zero.
     // We adjust it to the maximum value.

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -18,10 +18,12 @@ export const defaultCountryStyle =
     const { countryValue, minValue, maxValue, color } = context;
 
     let opacityLevel = 0;
-    if (typeof countryValue === "number")
+    if (typeof countryValue === "number") {
       opacityLevel =
         0.2 + 0.6 * ((countryValue - minValue) / (maxValue - minValue));
-    else if (typeof countryValue === "string") opacityLevel = 0.8;
+    } else if (typeof countryValue === "string") {
+      opacityLevel = 0.8;
+    }
 
     // If there's only one value, the calculation would be dividing by zero.
     // We adjust it to the maximum value.

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -18,7 +18,7 @@ export const defaultCountryStyle =
     const { countryValue, minValue, maxValue, color } = context;
 
     const calculatedValue = typeof countryValue === "string" ? minValue : countryValue;
-    let opacityLevel = calculatedValue !== undefined
+    let opacityLevel = calculatedValue !== undefined 
       ? 0.2 + 0.6 * ((calculatedValue - minValue) / (maxValue - minValue))
       : 0;
 

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -18,7 +18,11 @@ export const defaultCountryStyle =
     const { countryValue, minValue, maxValue, color } = context;
 
     const calculatedValue =
-      typeof countryValue === "string" ? minValue : countryValue;
+      // TODO bug in TS-ESLint; report this
+       
+      typeof countryValue === "string"
+        ? minValue
+        : (countryValue );
     let opacityLevel =
       calculatedValue !== undefined
         ? 0.2 + 0.6 * ((calculatedValue - minValue) / (maxValue - minValue))

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, createRef } from "react";
 import type GeoJSON from "geojson";
 import { geoMercator, geoPath } from "d3-geo";
 import geoData from "./countries.geo";
-import type { Props, CountryContext } from "./types";
+import type { Props, CountryContext, DataItem } from "./types";
 import {
   defaultColor,
   defaultSize,
@@ -25,6 +25,10 @@ export type {
   CountryContext,
   Props,
 } from "./types";
+
+function toValue({ value }: DataItem): number {
+  return typeof value === 'string' ? 0 : value;
+}
 
 export default function WorldMap(props: Props): JSX.Element {
   const {
@@ -64,12 +68,8 @@ export default function WorldMap(props: Props): JSX.Element {
     data.map(({ country, value }) => [country.toUpperCase(), value]),
   );
 
-  let minValue = 0;
-  let maxValue = 0;
-  if (data.every(({ value }) => typeof value === "number")) {
-    minValue = Math.min(...data.map(({ value }) => value as number));
-    maxValue = Math.max(...data.map(({ value }) => value as number));
-  }
+  const minValue = Math.min(...data.map(toValue));
+  const maxValue = Math.max(...data.map(toValue));
 
   // Build a path & a tooltip for each country
   const projection = geoMercator();

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -63,8 +63,13 @@ export default function WorldMap(props: Props): JSX.Element {
   const countryValueMap = Object.fromEntries(
     data.map(({ country, value }) => [country.toUpperCase(), value]),
   );
-  const minValue = Math.min(...data.map(({ value }) => value));
-  const maxValue = Math.max(...data.map(({ value }) => value));
+
+  let minValue = 0;
+  let maxValue = 0;
+  if (typeof data[0].value === "number") {
+    minValue = Math.min(...data.map(({ value }) => value as number));
+    maxValue = Math.max(...data.map(({ value }) => value as number));
+  }
 
   // Build a path & a tooltip for each country
   const projection = geoMercator();

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -26,11 +26,13 @@ export type {
   Props,
 } from "./types";
 
-function toValue({ value }: DataItem): number {
-  return typeof value === 'string' ? 0 : value;
+function toValue({ value }: DataItem<string | number>): number {
+  return typeof value === "string" ? 0 : value;
 }
 
-export default function WorldMap(props: Props): JSX.Element {
+export default function WorldMap<T extends number | string>(
+  props: Props<T>,
+): JSX.Element {
   const {
     data,
     title,
@@ -76,7 +78,7 @@ export default function WorldMap(props: Props): JSX.Element {
   const pathGenerator = geoPath().projection(projection);
 
   const onClick = React.useCallback(
-    (context: CountryContext) => (event: React.MouseEvent<SVGElement>) =>
+    (context: CountryContext<T>) => (event: React.MouseEvent<SVGElement>) =>
       onClickFunction?.({ ...context, event }),
     [onClickFunction],
   );
@@ -92,7 +94,7 @@ export default function WorldMap(props: Props): JSX.Element {
         coordinates: coordinates as unknown as GeoJSON.Position[][][],
       },
     };
-    const context: CountryContext = {
+    const context: CountryContext<T> = {
       countryCode: isoCode,
       countryValue: countryValueMap[isoCode],
       countryName,

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -66,7 +66,7 @@ export default function WorldMap(props: Props): JSX.Element {
 
   let minValue = 0;
   let maxValue = 0;
-  if (typeof data[0].value === "number") {
+  if (data.every(({ value }) => typeof value === "number")) {
     minValue = Math.min(...data.map(({ value }) => value as number));
     maxValue = Math.max(...data.map(({ value }) => value as number));
   }

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -7,17 +7,17 @@ export type ISOCode =
   | Lowercase<typeof isoCodes[number]>;
 export type SizeOption = "sm" | "md" | "lg" | "xl" | "xxl";
 
-export interface DataItem {
+export interface DataItem<T extends string | number = number> {
   country: ISOCode;
-  value: number | string;
+  value: T;
 }
 
-export type Data = DataItem[];
+export type Data<T extends string | number = number> = DataItem<T>[];
 
-export interface CountryContext {
+export interface CountryContext<T extends string | number = number> {
   countryCode: ISOCode;
   countryName: string;
-  countryValue?: number | string | undefined;
+  countryValue?: T | undefined;
   color: string;
   minValue: number;
   maxValue: number;
@@ -25,8 +25,8 @@ export interface CountryContext {
   suffix: string;
 }
 
-export interface Props {
-  data: DataItem[];
+export interface Props<T extends string | number = number> {
+  data: DataItem<T>[];
   title?: string;
   valuePrefix?: string;
   valueSuffix?: string;
@@ -43,16 +43,16 @@ export interface Props {
   /** @deprecated */
   type?: string; // Deprecated for the time being (reasoning in the README.md file)
 
-  styleFunction?: (context: CountryContext) => React.CSSProperties;
+  styleFunction?: (context: CountryContext<T>) => React.CSSProperties;
 
   onClickFunction?: (
-    context: CountryContext & { event: React.MouseEvent<SVGElement, Event> },
+    context: CountryContext<T> & { event: React.MouseEvent<SVGElement, Event> },
   ) => void;
 
-  tooltipTextFunction?: (context: CountryContext) => string;
+  tooltipTextFunction?: (context: CountryContext<T>) => string;
 
   hrefFunction?: (
-    context: CountryContext,
+    context: CountryContext<T>,
   ) => React.ComponentProps<"a"> | string | undefined;
 
   textLabelFunction?: (

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -9,7 +9,7 @@ export type SizeOption = "sm" | "md" | "lg" | "xl" | "xxl";
 
 export interface DataItem {
   country: ISOCode;
-  value: number;
+  value: number | string;
 }
 
 export type Data = DataItem[];
@@ -17,7 +17,7 @@ export type Data = DataItem[];
 export interface CountryContext {
   countryCode: ISOCode;
   countryName: string;
-  countryValue?: number | undefined;
+  countryValue?: number | string | undefined;
   color: string;
   minValue: number;
   maxValue: number;

--- a/website/src/components/StringValue.tsx
+++ b/website/src/components/StringValue.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import WorldMap from "react-svg-worldmap";
+import WorldMap, { type Data } from "react-svg-worldmap";
 
 export default function App(): JSX.Element {
-  const data = [
+  const data: Data<string> = [
     { country: "cn", value: "🇨🇳" }, // China
     { country: "in", value: "🇮🇳" }, // India
   ];

--- a/website/src/components/StringValue.tsx
+++ b/website/src/components/StringValue.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import WorldMap from "react-svg-worldmap";
+
+export default function App(): JSX.Element {
+  const data = [
+    { country: "cn", value: "🇨🇳" }, // China
+    { country: "in", value: "🇮🇳" }, // India
+  ];
+
+  return (
+    <WorldMap color="green" title="This is My Map" size="lg" data={data} />
+  );
+}

--- a/website/src/pages/examples/string-value.tsx
+++ b/website/src/pages/examples/string-value.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import CodeBlock from "@theme/CodeBlock";
+
+import Map from "@site/src/components/StringValue";
+import Source from "!!raw-loader!@site/src/components/StringValue";
+import styles from "./styles.module.css";
+
+export default function StringValue(): JSX.Element {
+  return (
+    <Layout title="String Value example">
+      <div className={styles.main}>
+        <Map />
+        <div className={styles.code}>
+          <CodeBlock className="language-tsx">{Source}</CodeBlock>
+        </div>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
This feature adds support for `string` and the value `0` for the `value` prop.
Currently the code only checks if the value is false-y, so it now supports a 0 value.
Other consumers of this worldmap (myself being one of them), may want to display non-numeric information next to the country name. Personally I would like to display world flags, which cannot be done at the moment.

fix #126