### PR TITLE
Add new responsive algorithm

### DIFF
--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -36,7 +36,7 @@ export interface Props<T extends string | number = number> {
   tooltipBgColor?: string;
   tooltipTextColor?: string;
   rtl?: boolean;
-  size?: SizeOption | "responsive" | number;
+  size?: SizeOption | "responsive" | "responsive-100" | number;
   frame?: boolean;
   frameColor?: string;
   borderColor?: string;

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -28,9 +28,15 @@ export function useWindowWidth(): number {
 
 // Adjust responsive size
 export function responsify(
-  sizeOption: SizeOption | "responsive",
+  sizeOption: SizeOption | "responsive" | "responsive-100",
   windowWidth: number,
 ): number {
+  if (sizeOption === "responsive-100") {
+    // Make component work in SSR
+    if (typeof window === "undefined") return sizeMap[defaultSize];
+
+    return window.innerWidth;
+  }
   if (sizeOption === "responsive") {
     // Make component work in SSR
     if (typeof window === "undefined") return sizeMap[defaultSize];


### PR DESCRIPTION
Actually take up 100% of the window width - ignore, height, as we're calculating the width here.

![image](https://github.com/yanivam/react-svg-worldmap/assets/5943908/1080e4c6-9d31-4233-b293-3deca91c05eb)

Might fix #149